### PR TITLE
Update README to exclude npm from installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,10 @@ Server-side Node.JS library for interacting with the Streem API, and generation 
 
 ## Installation
 
-Add the Streem SDK dependency to your project
+Add the Streem SDK dependency to your project. Yarn is required:
 
 ```
 yarn add @streem/sdk-node
-```
-
-Or
-
-```
-npm install @streem/sdk-node
 ```
 
 ## Usage


### PR DESCRIPTION
STREEM-11462

Update `README` to exclude `npm install...` from installation instructions.

Yarn is the only supported package manager for `streem-sdk-node`, and attempting to install via `npm` causes an error